### PR TITLE
LIBTD-1335: Migrate Composition+Performance Work creation/update functionality to Hyrax 2.1.0

### DIFF
--- a/app/actors/hyrax/actors/composition_actor.rb
+++ b/app/actors/hyrax/actors/composition_actor.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+module Hyrax
+  module Actors
+    class CompositionActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/actors/hyrax/actors/performance_actor.rb
+++ b/app/actors/hyrax/actors/performance_actor.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+module Hyrax
+  module Actors
+    class PerformanceActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,7 +82,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
     config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
-    config.add_index_field solr_name("based_near_label", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near_label", :facetable)
+    config.add_index_field solr_name("based_near", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near", :facetable)
     config.add_index_field solr_name("language", :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
@@ -104,7 +104,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("creator", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
     config.add_show_field solr_name("publisher", :stored_searchable)
-    config.add_show_field solr_name("based_near_label", :stored_searchable)
+    config.add_show_field solr_name("based_near", :stored_searchable)
     config.add_show_field solr_name("language", :stored_searchable)
     config.add_show_field solr_name("date_uploaded", :stored_searchable)
     config.add_show_field solr_name("date_modified", :stored_searchable)
@@ -243,7 +243,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field('based_near') do |field|
       field.label = "Location"
-      solr_name = solr_name("based_near_label", :stored_searchable)
+      solr_name = solr_name("based_near", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -31,7 +31,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim"
+      qf: "title_tesim description_tesim composer_tesim performer_tesim, tags_tesim"
     }
 
     # solr field configuration for document/show views
@@ -41,12 +41,12 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
-    config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
-    config.add_facet_field solr_name("creator", :facetable), limit: 5
-    config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
-    config.add_facet_field solr_name("keyword", :facetable), limit: 5
-    config.add_facet_field solr_name("subject", :facetable), limit: 5
+    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 2
+    config.add_facet_field solr_name("genre", :facetable), label: "Genre", limit: 5
+    config.add_facet_field solr_name("composer", :facetable), label: "Composer", limit: 5
+    config.add_facet_field solr_name("performer", :facetable), label: "Performer", limit: 5
+    config.add_facet_field solr_name("instruments", :facetable), label: "Instruments", limit: 5
+    config.add_facet_field solr_name("tags", :facetable), label: "Tags", limit: 5
     config.add_facet_field solr_name("language", :facetable), limit: 5
     config.add_facet_field solr_name("based_near_label", :facetable), limit: 5
     config.add_facet_field solr_name("publisher", :facetable), limit: 5
@@ -65,10 +65,20 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
+    config.add_index_field solr_name("composer", :stored_searchable), label: "Composer", link_to_search: solr_name("composer", :facetable)
+    config.add_index_field solr_name("performer", :stored_searchable), label: "Performer", link_to_search: solr_name("performer", :facetable)
+
     config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
-    config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
-    config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
+
+    config.add_index_field solr_name("instruments", :stored_searchable), label: "Instruments", link_to_search: solr_name("instruments", :facetable)
+    config.add_index_field solr_name("date", :stored_searchable), label: "Date"
+    config.add_index_field solr_name("tags", :stored_searchable), label: "Tags", link_to_search: solr_name("tags", :facetable)
+    config.add_index_field solr_name("length", :stored_searchable), label: "Length"
+    config.add_index_field solr_name("genre", :stored_searchable), label: "Genre", link_to_search: solr_name("Genre", :facetable)
+    config.add_index_field solr_name("software", :stored_searchable), label: "Software"
+    config.add_index_field solr_name("medium", :stored_searchable), label: "Medium"
+    config.add_index_field solr_name("location", :stored_searchable), label: "Location"
+
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,7 +77,6 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("genre", :stored_searchable), label: "Genre", link_to_search: solr_name("Genre", :facetable)
     config.add_index_field solr_name("software", :stored_searchable), label: "Software"
     config.add_index_field solr_name("medium", :stored_searchable), label: "Medium"
-    config.add_index_field solr_name("location", :stored_searchable), label: "Location"
 
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile

--- a/app/controllers/hyrax/compositions_controller.rb
+++ b/app/controllers/hyrax/compositions_controller.rb
@@ -11,10 +11,15 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = MusicWorkPresenter
 
+    def new
+      curation_concern.composer = [current_user.user_key]
+      super
+    end
+
     def show
       super
-      #comp = Composition.find(params[:id])
-      #@performances = comp.performances      
+      comp = Composition.find(params[:id])
+      @performances = comp.performances
     end
   end
 end

--- a/app/controllers/hyrax/compositions_controller.rb
+++ b/app/controllers/hyrax/compositions_controller.rb
@@ -1,0 +1,20 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+module Hyrax
+  # Generated controller for Composition
+  class CompositionsController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::Composition
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = MusicWorkPresenter
+
+    def show
+      super
+      #comp = Composition.find(params[:id])
+      #@performances = comp.performances      
+    end
+  end
+end

--- a/app/controllers/hyrax/performances_controller.rb
+++ b/app/controllers/hyrax/performances_controller.rb
@@ -1,0 +1,28 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+module Hyrax
+  # Generated controller for Performance
+  class PerformancesController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::Performance
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = MusicWorkPresenter
+
+    def new
+      curation_concern.performer = [current_user.user_key]
+      super
+    end
+
+    def show
+      super
+      perf = Performance.find(params[:id])
+      @composition = perf.composition
+      if !@composition.nil?
+        @composer_link = "/users/#{@composition.composer.first.gsub('.', '-dot-')}"
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/composition_form.rb
+++ b/app/forms/hyrax/composition_form.rb
@@ -1,0 +1,26 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+module Hyrax
+  # Generated form for Composition
+  class CompositionForm < Hyrax::Forms::WorkForm
+    self.model_class = ::Composition
+    self.terms -= [:creator, :keyword, :subject]
+    self.terms += [:instruments, :date, :tags,
+                   :length, :genre, :software, :medium, :composer]
+
+    self.required_fields = [:title, :instruments]
+
+    # Fields that are automatically drawn on the page below the fold
+    def secondary_terms
+      terms - primary_terms -
+        [:contributor, :rights, :publisher, :date_created, :language,
+         :identifier, :base_near, :related_url, :source,
+         :files, :visibility_during_embargo, :embargo_release_date,
+         :visibility_after_embargo, :visibility_during_lease,
+         :lease_expiration_date, :visibility_after_lease, :visibility,
+         :thumbnail_id, :representative_id, :ordered_member_ids,
+         :member_of_collection_ids, :in_works_ids, :admin_set_id,
+         :license, :rights_statement, :rendering_ids]
+    end
+  end
+end

--- a/app/forms/hyrax/performance_form.rb
+++ b/app/forms/hyrax/performance_form.rb
@@ -6,7 +6,7 @@ module Hyrax
     self.model_class = ::Performance
     self.terms -= [:creator, :keyword, :subject, :license, :rendering_ids]
     self.terms += [:composition_id, :instruments, :date, :tags,
-                   :length, :genre, :software, :medium, :location, :performer]
+                   :length, :genre, :software, :medium, :performer]
 
     self.required_fields = [:title, :instruments]
 

--- a/app/forms/hyrax/performance_form.rb
+++ b/app/forms/hyrax/performance_form.rb
@@ -1,0 +1,29 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+module Hyrax
+  # Generated form for Performance
+  class PerformanceForm < Hyrax::Forms::WorkForm
+    self.model_class = ::Performance
+    self.terms -= [:creator, :keyword, :subject, :license, :rendering_ids]
+    self.terms += [:composition_id, :instruments, :date, :tags,
+                   :length, :genre, :software, :medium, :location, :performer]
+
+    self.required_fields = [:title, :instruments]
+
+    def primary_terms
+      [:title, :composition_id, :instruments]
+    end
+    
+    # Fields that are automatically drawn on the page below the fold
+    def secondary_terms
+      terms - primary_terms -
+        [:contributor, :rights, :publisher, :date_created, :language,
+         :identifier, :base_near, :related_url, :source,
+         :files, :visibility_during_embargo, :embargo_release_date,
+         :visibility_after_embargo, :visibility_during_lease,
+         :lease_expiration_date, :visibility_after_lease, :visibility,
+         :thumbnail_id, :representative_id, :ordered_member_ids,
+         :member_of_collection_ids, :in_works_ids, :admin_set_id]
+    end
+  end
+end

--- a/app/indexers/composition_indexer.rb
+++ b/app/indexers/composition_indexer.rb
@@ -1,0 +1,18 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+class CompositionIndexer < Hyrax::WorkIndexer
+  # This indexes the default metadata. You can remove it if you want to
+  # provide your own metadata and indexing.
+  include Hyrax::IndexesBasicMetadata
+
+  # Fetch remote labels for based_near. You can remove this if you don't want
+  # this behavior
+  include Hyrax::IndexesLinkedMetadata
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  # def generate_solr_document
+  #  super.tap do |solr_doc|
+  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
+  #  end
+  # end
+end

--- a/app/indexers/performance_indexer.rb
+++ b/app/indexers/performance_indexer.rb
@@ -1,0 +1,18 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+class PerformanceIndexer < Hyrax::WorkIndexer
+  # This indexes the default metadata. You can remove it if you want to
+  # provide your own metadata and indexing.
+  include Hyrax::IndexesBasicMetadata
+
+  # Fetch remote labels for based_near. You can remove this if you don't want
+  # this behavior
+  include Hyrax::IndexesLinkedMetadata
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  # def generate_solr_document
+  #  super.tap do |solr_doc|
+  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
+  #  end
+  # end
+end

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -1,0 +1,25 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+class Composition < ActiveFedora::Base
+  include ::Hyrax::WorkBehavior
+  include ::Compel::Metadata
+
+  self.indexer = CompositionIndexer
+  # Change this to restrict which works can be added as a child.
+  # self.valid_child_concerns = []
+  validates :title, presence: { message: 'Your composition must have a title.' }
+  validates :composer, presence: { message: 'Your composition must have a composer.' }
+  validates :instruments, presence: { message: 'Your composition must have instruments.' }
+
+  self.human_readable_type = 'Composition'
+
+  property :composer, predicate: ::RDF::Vocab::DC11.creator do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  #has_many :performances
+
+  # This must be included at the end, because it finalizes the metadata
+  # schema (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
+end

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -17,7 +17,7 @@ class Composition < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  #has_many :performances
+  has_many :performances
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)

--- a/app/models/concerns/compel/metadata.rb
+++ b/app/models/concerns/compel/metadata.rb
@@ -24,9 +24,6 @@ module Compel
       property :medium, predicate: ::RDF::Vocab::DC.medium do |index|
         index.as :stored_searchable
       end
-      property :location, predicate: ::RDF::Vocab::DC.Location do |index|
-        index.as :stored_searchable
-      end
     end
   end
 end

--- a/app/models/concerns/compel/metadata.rb
+++ b/app/models/concerns/compel/metadata.rb
@@ -1,0 +1,32 @@
+module Compel
+  module Metadata
+    extend ActiveSupport::Concern
+
+    included do
+      property :genre, predicate: ::RDF::Vocab::DC11.type do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :instruments, predicate: ::RDF::Vocab::DC11.relation do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :date, predicate: ::RDF::Vocab::DC11.date, multiple: false do |index|
+        index.as :stored_searchable, :stored_sortable
+      end
+      property :tags, predicate: ::RDF::Vocab::DC11.subject do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :length, predicate: ::RDF::Vocab::DC.extent, multiple: false do |index|
+        index.as :stored_searchable
+      end
+      property :software, predicate: ::RDF::Vocab::DCMIType.Software do |index|
+        index.as :stored_searchable
+      end
+      property :medium, predicate: ::RDF::Vocab::DC.medium do |index|
+        index.as :stored_searchable
+      end
+      property :location, predicate: ::RDF::Vocab::DC.Location do |index|
+        index.as :stored_searchable
+      end
+    end
+  end
+end

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -1,0 +1,45 @@
+# Modified from Hyrax Gem 2.1.0: Modified based_near to remove controlled vocabulary
+
+module Hyrax
+  # An optional model mixin to define some simple properties. This must be mixed
+  # after all other properties are defined because no other properties will
+  # be defined once  accepts_nested_attributes_for is called
+  module BasicMetadata
+    extend ActiveSupport::Concern
+
+    included do
+      property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
+
+      property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
+
+      property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
+      property :resource_type, predicate: ::RDF::Vocab::DC.type
+      property :creator, predicate: ::RDF::Vocab::DC11.creator
+      property :contributor, predicate: ::RDF::Vocab::DC11.contributor
+      property :description, predicate: ::RDF::Vocab::DC11.description
+      property :keyword, predicate: ::RDF::Vocab::DC11.relation
+      # Used for a license
+      property :license, predicate: ::RDF::Vocab::DC.rights
+
+      # This is for the rights statement
+      property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
+      property :publisher, predicate: ::RDF::Vocab::DC11.publisher
+      property :date_created, predicate: ::RDF::Vocab::DC.created
+      property :subject, predicate: ::RDF::Vocab::DC11.subject
+      property :language, predicate: ::RDF::Vocab::DC11.language
+      property :identifier, predicate: ::RDF::Vocab::DC.identifier
+      # Modified for COMPEL: begin
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near
+      # Modified for COMPEL: end
+      property :related_url, predicate: ::RDF::RDFS.seeAlso
+      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation
+      property :source, predicate: ::RDF::Vocab::DC.source
+
+      id_blank = proc { |attributes| attributes[:id].blank? }
+
+      class_attribute :controlled_properties
+      self.controlled_properties = [:based_near]
+      accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+    end
+  end
+end

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -1,0 +1,26 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+class Performance < ActiveFedora::Base
+  include ::Hyrax::WorkBehavior
+  include ::Compel::Metadata
+
+  self.indexer = PerformanceIndexer
+  # Change this to restrict which works can be added as a child.
+  # self.valid_child_concerns = []
+
+  validates :title, presence: { message: 'Your performance must have a title.' }
+  validates :performer, presence: { message: 'Your performance must have a performer.' }
+  validates :instruments, presence: { message: 'Your performance must have instruments.' }
+
+  self.human_readable_type = 'Performance'
+
+  property :performer, predicate: ::RDF::Vocab::DC11.creator do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  belongs_to :composition, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
+
+  # This must be included at the end, because it finalizes the metadata
+  # schema (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -61,8 +61,4 @@ class SolrDocument
   def medium
     self[Solrizer.solr_name('medium')]
   end
-
-  def location
-    self[Solrizer.solr_name('location')]
-  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,4 +25,44 @@ class SolrDocument
   # Do content negotiation for AF models. 
 
   use_extension( Hydra::ContentNegotiation )
+
+  def composer
+    self[Solrizer.solr_name('composer')]
+  end
+
+  def performer
+    self[Solrizer.solr_name('performer')]
+  end
+
+  def instruments
+    self[Solrizer.solr_name('instruments')]
+  end
+
+  def date
+    self[Solrizer.solr_name('date')]
+  end
+
+  def tags
+    self[Solrizer.solr_name('tags')]
+  end
+
+  def length
+    self[Solrizer.solr_name('length')]
+  end
+
+  def genre
+    self[Solrizer.solr_name('genre')]
+  end
+
+  def software
+    self[Solrizer.solr_name('software')]
+  end
+
+  def medium
+    self[Solrizer.solr_name('medium')]
+  end
+
+  def location
+    self[Solrizer.solr_name('location')]
+  end
 end

--- a/app/presenters/hyrax/composition_presenter.rb
+++ b/app/presenters/hyrax/composition_presenter.rb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+module Hyrax
+  class CompositionPresenter < Hyrax::WorkShowPresenter
+  end
+end

--- a/app/presenters/hyrax/performance_presenter.rb
+++ b/app/presenters/hyrax/performance_presenter.rb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+module Hyrax
+  class PerformancePresenter < Hyrax::WorkShowPresenter
+  end
+end

--- a/app/presenters/music_work_presenter.rb
+++ b/app/presenters/music_work_presenter.rb
@@ -1,4 +1,4 @@
 class MusicWorkPresenter < Hyrax::WorkShowPresenter
   delegate :composer, :performer, :instruments, :date, :tags, :length,       
-           :genre, :software, :medium, :location, to: :solr_document
+           :genre, :software, :medium, to: :solr_document
 end

--- a/app/presenters/music_work_presenter.rb
+++ b/app/presenters/music_work_presenter.rb
@@ -1,0 +1,4 @@
+class MusicWorkPresenter < Hyrax::WorkShowPresenter
+  delegate :composer, :performer, :instruments, :date, :tags, :length,       
+           :genre, :software, :medium, :location, to: :solr_document
+end

--- a/app/services/compositions_service.rb
+++ b/app/services/compositions_service.rb
@@ -1,0 +1,17 @@
+module CompositionsService
+  mattr_accessor :authority
+  self.authority = Composition
+
+  def self.select_all_options
+    authority.all.map do |element|
+      [label(element.id), element.id]
+    end
+  end
+
+  def self.label(id)
+    comp = authority.find(id)
+    "#{comp.title.first} | #{comp.composer.first}"
+  end
+
+end
+

--- a/app/services/tags_service.rb
+++ b/app/services/tags_service.rb
@@ -1,0 +1,14 @@
+module TagsService
+  mattr_accessor :authority
+  self.authority = Qa::Authorities::Local.subauthority_for('tags')
+
+  def self.select_all_options
+    authority.all.map do |element|
+      [element[:label], element[:id]]
+    end
+  end
+
+  def self.label(id)
+    authority.find(id).fetch('term')
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -7,5 +7,3 @@
 <%= presenter.attribute_to_html(:genre, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:software) %>
 <%= presenter.attribute_to_html(:medium) %>
-<%= presenter.attribute_to_html(:location) %>
-

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,0 +1,11 @@
+<%= presenter.attribute_to_html(:composer, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:performer, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:instruments, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:date, render_as: :linked, search_field: 'date_tesim') %>
+<%= presenter.attribute_to_html(:tags, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:length) %>
+<%= presenter.attribute_to_html(:genre, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:software) %>
+<%= presenter.attribute_to_html(:medium) %>
+<%= presenter.attribute_to_html(:location) %>
+

--- a/app/views/hyrax/base/_performance_composition_info.html.erb
+++ b/app/views/hyrax/base/_performance_composition_info.html.erb
@@ -1,0 +1,11 @@
+<% if !composition.nil? %>
+  <h2>Composition</h2>
+  <div>
+    <strong>Performance of:</strong> <%= link_to "#{composition.title.first}", "/concern/compositions/#{composition.id}" %>
+  </div>
+  <div>
+    <strong>Composed by:</strong> <span class="composition-composer"><%= link_to composition.composer.first, composer_link %></span>
+  </div>
+  <br />
+<% end %>
+

--- a/app/views/hyrax/base/_performance_row.html.erb
+++ b/app/views/hyrax/base/_performance_row.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <th><%= link_to performance.title.first, "/concern/performances/#{performance.id}" %></th>
+  <td>
+    Performed by: <%= link_to performance.performer.first, "/users/#{performance.performer.first.gsub('.','-dot-')}" %>
+  </td>
+</tr>
+

--- a/app/views/hyrax/base/_performances.html.erb
+++ b/app/views/hyrax/base/_performances.html.erb
@@ -1,0 +1,13 @@
+<h2>Performances</h2>
+<% if performances.blank? %>
+  <p>There are currently no performances of this Composition</p>
+<% else %>
+  <table class="table table-striped relationships">
+    <tbody>
+      <% performances.each do |performance| %>
+        <%= render 'performance_row', performance: performance %>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,56 @@
+<%# Modified from Hyrax 2.1.0 Gem %>
+<%# - Adding rendering of performance_composition_info %>
+<%# - Adding rendering of performances %>
+
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
+<div class="row work-type">
+  <div class="col-xs-12">
+    <%= render 'work_type', presenter: @presenter %>
+  </div>
+  <div class="col-xs-12">&nbsp;</div>
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <%= render 'work_title', presenter: @presenter %>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.universal_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <% end %>
+          <div class="col-sm-3 text-center">
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <%= render 'citations', presenter: @presenter %>
+            <%= render 'social_media' %>
+          </div>
+          <div class="col-sm-9">
+            <%# COMPEL-specific rendering: begin %>
+            <%= render("performance_composition_info", presenter: @presenter,
+                       composition: @composition, composer_link: @composer_link) if controller_name == "performances" %>
+            <%# COMPEL-specific rendering: end %>
+
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+          </div>
+          <div class="col-sm-12">
+            <%= render 'relationships', presenter: @presenter %>
+            <%= render 'items', presenter: @presenter %>
+            <%# TODO: we may consider adding these partials in the future %>
+            <%# = render 'sharing_with', presenter: @presenter %>
+            <%# = render 'user_activity', presenter: @presenter %>
+
+            <%# COMPEL-specific rendering: begin %>
+            <%= render('performances', performances: @performances) if controller_name == "compositions" %>
+            <%# COMPEL-specific rendering: end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/compositions/_composition.html.erb
+++ b/app/views/hyrax/compositions/_composition.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: composition, document_counter: composition_counter  %>

--- a/app/views/hyrax/performances/_performance.html.erb
+++ b/app/views/hyrax/performances/_performance.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: performance, document_counter: performance_counter  %>

--- a/app/views/records/edit_fields/_based_near.html.erb
+++ b/app/views/records/edit_fields/_based_near.html.erb
@@ -1,0 +1,6 @@
+<%# Modified from Hyrax Gem 2.1.0: Changed from geonames autocomplete field to a plain input field %>
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/edit_fields/_composition_id.html.erb
+++ b/app/views/records/edit_fields/_composition_id.html.erb
@@ -1,0 +1,7 @@
+<%= f.input :composition_id, as: :select,
+    collection: CompositionsService.select_all_options,
+    include_blank: true,
+    #item_helper: method(:include_current_value),
+    input_html: { class: 'form-control' }
+%>
+

--- a/app/views/records/edit_fields/_tags.html.erb
+++ b/app/views/records/edit_fields/_tags.html.erb
@@ -1,0 +1,5 @@
+<%= f.input :tags, as: :select,
+    collection: TagsService.select_all_options,
+    include_blank: true,
+    input_html: { class: 'form-control', multiple: true }
+%>

--- a/config/authorities/tags.yml
+++ b/config/authorities/tags.yml
@@ -1,0 +1,8 @@
+terms:
+  - id: electronic
+    term: electronic
+  - id: ambient
+    term: ambient
+  - id: psytrance
+    term: psytrance
+

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,6 +1,8 @@
 Hyrax.config do |config|
   # Injected via `rails g hyrax:work Composition`
   config.register_curation_concern :composition
+  # Injected via `rails g hyrax:work Performance`
+  config.register_curation_concern :performance
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,4 +1,6 @@
 Hyrax.config do |config|
+  # Injected via `rails g hyrax:work Composition`
+  config.register_curation_concern :composition
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/config/locales/composition.de.yml
+++ b/config/locales/composition.de.yml
@@ -1,0 +1,8 @@
+de:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        description:        "Composition Werke"
+        name:               "Composition"

--- a/config/locales/composition.en.yml
+++ b/config/locales/composition.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        description:        "Composition works"
+        name:               "Composition"

--- a/config/locales/composition.es.yml
+++ b/config/locales/composition.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        # TODO: translate `human_name` into Spanish
+        description:        "Composition trabajos"
+        name:               "Composition"
+        # TODO: translate `human_name` into Spanish

--- a/config/locales/composition.fr.yml
+++ b/config/locales/composition.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        description:        "Composition œuvres"
+        name:               "Composition"

--- a/config/locales/composition.it.yml
+++ b/config/locales/composition.it.yml
@@ -1,0 +1,8 @@
+it:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        description:        "Composition opere"
+        name:               "Composition"

--- a/config/locales/composition.pt-BR.yml
+++ b/config/locales/composition.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        description:        "Composition trabalhos"
+        name:               "Composition"

--- a/config/locales/composition.zh.yml
+++ b/config/locales/composition.zh.yml
@@ -1,0 +1,10 @@
+zh:
+  hyrax:
+    icons:
+      composition:     'fa fa-file-text-o'
+    select_type:
+      composition:
+        # TODO: translate `human_name` into Chinese
+        description:        "Composition 作品"
+        name:               "Composition"
+        # TODO: translate `human_name` into Chinese

--- a/config/locales/performance.de.yml
+++ b/config/locales/performance.de.yml
@@ -1,0 +1,8 @@
+de:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        description:        "Performance Werke"
+        name:               "Performance"

--- a/config/locales/performance.en.yml
+++ b/config/locales/performance.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        description:        "Performance works"
+        name:               "Performance"

--- a/config/locales/performance.es.yml
+++ b/config/locales/performance.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        # TODO: translate `human_name` into Spanish
+        description:        "Performance trabajos"
+        name:               "Performance"
+        # TODO: translate `human_name` into Spanish

--- a/config/locales/performance.fr.yml
+++ b/config/locales/performance.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        description:        "Performance œuvres"
+        name:               "Performance"

--- a/config/locales/performance.it.yml
+++ b/config/locales/performance.it.yml
@@ -1,0 +1,8 @@
+it:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        description:        "Performance opere"
+        name:               "Performance"

--- a/config/locales/performance.pt-BR.yml
+++ b/config/locales/performance.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        description:        "Performance trabalhos"
+        name:               "Performance"

--- a/config/locales/performance.zh.yml
+++ b/config/locales/performance.zh.yml
@@ -1,0 +1,10 @@
+zh:
+  hyrax:
+    icons:
+      performance:     'fa fa-file-text-o'
+    select_type:
+      performance:
+        # TODO: translate `human_name` into Chinese
+        description:        "Performance 作品"
+        name:               "Performance"
+        # TODO: translate `human_name` into Chinese

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,10 @@
 
 ActiveRecord::Schema.define(version: 20180604153605) do
 
-  create_table "bookmarks", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -50,7 +53,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "collection_type_participants", force: :cascade do |t|
-    t.integer "hyrax_collection_type_id"
+    t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -74,7 +77,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.string "job_id"
     t.string "type"
     t.text "message"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.integer "parent_id"
     t.integer "lft", null: false
     t.integer "rgt", null: false
@@ -144,8 +147,8 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "uploaded_file_id"
+    t.bigint "user_id"
+    t.bigint "uploaded_file_id"
     t.string "file_set_id"
     t.string "mime_type"
     t.string "original_name"
@@ -157,7 +160,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -165,13 +168,13 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :serial, force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :serial, force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -194,7 +197,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -211,11 +214,11 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :serial, force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -223,7 +226,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "permission_template_accesses", force: :cascade do |t|
-    t.integer "permission_template_id"
+    t.bigint "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -245,8 +248,8 @@ ActiveRecord::Schema.define(version: 20180604153605) do
 
   create_table "proxy_deposit_requests", force: :cascade do |t|
     t.string "work_id", null: false
-    t.integer "sending_user_id", null: false
-    t.integer "receiving_user_id", null: false
+    t.bigint "sending_user_id", null: false
+    t.bigint "receiving_user_id", null: false
     t.datetime "fulfillment_date"
     t.string "status", default: "pending", null: false
     t.text "sender_comment"
@@ -258,8 +261,8 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "proxy_deposit_rights", force: :cascade do |t|
-    t.integer "grantor_id"
-    t.integer "grantee_id"
+    t.bigint "grantor_id"
+    t.bigint "grantee_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
@@ -274,7 +277,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "qa_local_authority_entries", force: :cascade do |t|
-    t.integer "local_authority_id"
+    t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -283,7 +286,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :serial, force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -473,7 +476,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
 
   create_table "uploaded_files", force: :cascade do |t|
     t.string "file"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "file_set_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -554,4 +557,12 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end

--- a/spec/actors/hyrax/actors/composition_actor_spec.rb
+++ b/spec/actors/hyrax/actors/composition_actor_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::CompositionActor do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/actors/hyrax/actors/performance_actor_spec.rb
+++ b/spec/actors/hyrax/actors/performance_actor_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::PerformanceActor do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/controllers/hyrax/compositions_controller_spec.rb
+++ b/spec/controllers/hyrax/compositions_controller_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+require 'rails_helper'
+
+RSpec.describe Hyrax::CompositionsController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/controllers/hyrax/performances_controller_spec.rb
+++ b/spec/controllers/hyrax/performances_controller_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+require 'rails_helper'
+
+RSpec.describe Hyrax::PerformancesController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/features/create_composition_spec.rb
+++ b/spec/features/create_composition_spec.rb
@@ -1,0 +1,69 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a Composition', js: false do
+  context 'a logged in user' do
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user.user_key,
+        access: 'deposit'
+      )
+      login_as user
+    end
+
+    scenario do
+      visit '/dashboard'
+      click_link "Works"
+      click_link "Add new work"
+
+      # If you generate more than one work uncomment these lines
+      # choose "payload_concern", option: "Composition"
+      # click_button "Create work"
+
+      expect(page).to have_content "Add New Composition"
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('span#addfiles') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
+      end
+      click_link "Descriptions" # switch tab
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Keyword', with: 'testing')
+      select('In Copyright', from: 'Rights statement')
+
+      # With selenium and the chrome driver, focus remains on the
+      # select box. Click outside the box so the next line can't find
+      # its element
+      find('body').click
+      choose('composition_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      check('agreement')
+
+      click_on('Save')
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+    end
+  end
+end

--- a/spec/features/create_performance_spec.rb
+++ b/spec/features/create_performance_spec.rb
@@ -1,0 +1,69 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a Performance', js: false do
+  context 'a logged in user' do
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user.user_key,
+        access: 'deposit'
+      )
+      login_as user
+    end
+
+    scenario do
+      visit '/dashboard'
+      click_link "Works"
+      click_link "Add new work"
+
+      # If you generate more than one work uncomment these lines
+      # choose "payload_concern", option: "Performance"
+      # click_button "Create work"
+
+      expect(page).to have_content "Add New Performance"
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('span#addfiles') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
+      end
+      click_link "Descriptions" # switch tab
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Keyword', with: 'testing')
+      select('In Copyright', from: 'Rights statement')
+
+      # With selenium and the chrome driver, focus remains on the
+      # select box. Click outside the box so the next line can't find
+      # its element
+      find('body').click
+      choose('performance_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      check('agreement')
+
+      click_on('Save')
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+    end
+  end
+end

--- a/spec/forms/hyrax/composition_form_spec.rb
+++ b/spec/forms/hyrax/composition_form_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+require 'rails_helper'
+
+RSpec.describe Hyrax::CompositionForm do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/forms/hyrax/performance_form_spec.rb
+++ b/spec/forms/hyrax/performance_form_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+require 'rails_helper'
+
+RSpec.describe Hyrax::PerformanceForm do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/models/composition_spec.rb
+++ b/spec/models/composition_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+require 'rails_helper'
+
+RSpec.describe Composition do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/models/performance_spec.rb
+++ b/spec/models/performance_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+require 'rails_helper'
+
+RSpec.describe Performance do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/presenters/hyrax/composition_presenter_spec.rb
+++ b/spec/presenters/hyrax/composition_presenter_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Composition`
+require 'rails_helper'
+
+RSpec.describe Hyrax::CompositionPresenter do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/presenters/hyrax/performance_presenter_spec.rb
+++ b/spec/presenters/hyrax/performance_presenter_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Performance`
+require 'rails_helper'
+
+RSpec.describe Hyrax::PerformancePresenter do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end


### PR DESCRIPTION
This pull requests contains modifications that essentially reimplement the Composition and Performance Work creation/update functionality to Hyrax 2.1.0 from Hyrax 1.0.3.

Code/Functionality is being migrated from:
https://github.com/VTUL/binary-arts/tree/5b89406e1aa662c2d5e039b370ea5067dbe26ac5 

The bulk of the Composition and Performance functionality is there, but customized stylesheets are still missing and can be added in later with LIBTD-1341. For example, the Composition Composer and Performance Performer are still visible in the forms, but this will change once the stylesheets have been brought over. 
