### PR TITLE
LIBTD-1340: Migrate Role Management + Collection functionality to Hyrax 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,5 @@ gem 'riiif', '~> 1.1'
 # Locally-used Gems
 gem 'pg'
 gem 'sidekiq'
+gem 'hydra-role-management'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
+    bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (0.15.1)
       addressable (~> 2.5)
@@ -288,6 +289,10 @@ GEM
     hydra-pcdm (0.11.0)
       active-fedora (>= 10, < 13)
       mime-types (>= 1)
+    hydra-role-management (1.0.0)
+      blacklight
+      bootstrap_form
+      cancancan
     hydra-works (0.17.0)
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 0.3, >= 0.3.3)
@@ -753,6 +758,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.6)
   fcrepo_wrapper
+  hydra-role-management
   hyrax (= 2.1.0)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,4 +4,6 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+
+  validates :title, presence: { message: 'Your collection must have a title.' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
+
+
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   end
 
   devise_for :users
+  mount Hydra::RoleManagement::Engine => '/'
+
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'

--- a/db/migrate/20180606201220_user_roles.rb
+++ b/db/migrate/20180606201220_user_roles.rb
@@ -1,0 +1,18 @@
+class UserRoles < ActiveRecord::Migration[5.0]
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, :id => false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, [:role_id, :user_id]
+    add_index :roles_users, [:user_id, :role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180604153605) do
+ActiveRecord::Schema.define(version: 20180606201220) do
 
-  create_table "bookmarks", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -50,7 +53,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "collection_type_participants", force: :cascade do |t|
-    t.integer "hyrax_collection_type_id"
+    t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -74,7 +77,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.string "job_id"
     t.string "type"
     t.text "message"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.integer "parent_id"
     t.integer "lft", null: false
     t.integer "rgt", null: false
@@ -144,8 +147,8 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "uploaded_file_id"
+    t.bigint "user_id"
+    t.bigint "uploaded_file_id"
     t.string "file_set_id"
     t.string "mime_type"
     t.string "original_name"
@@ -157,7 +160,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -165,13 +168,13 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :serial, force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :serial, force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -194,7 +197,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -211,11 +214,11 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :serial, force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -223,7 +226,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "permission_template_accesses", force: :cascade do |t|
-    t.integer "permission_template_id"
+    t.bigint "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -245,8 +248,8 @@ ActiveRecord::Schema.define(version: 20180604153605) do
 
   create_table "proxy_deposit_requests", force: :cascade do |t|
     t.string "work_id", null: false
-    t.integer "sending_user_id", null: false
-    t.integer "receiving_user_id", null: false
+    t.bigint "sending_user_id", null: false
+    t.bigint "receiving_user_id", null: false
     t.datetime "fulfillment_date"
     t.string "status", default: "pending", null: false
     t.text "sender_comment"
@@ -258,8 +261,8 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "proxy_deposit_rights", force: :cascade do |t|
-    t.integer "grantor_id"
-    t.integer "grantee_id"
+    t.bigint "grantor_id"
+    t.bigint "grantee_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
@@ -274,7 +277,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
   end
 
   create_table "qa_local_authority_entries", force: :cascade do |t|
-    t.integer "local_authority_id"
+    t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -283,7 +286,20 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+    t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+    t.index ["role_id"], name: "index_roles_users_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_roles_users_on_user_id"
+  end
+
+  create_table "searches", id: :serial, force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -473,7 +489,7 @@ ActiveRecord::Schema.define(version: 20180604153605) do
 
   create_table "uploaded_files", force: :cascade do |t|
     t.string "file"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "file_set_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -554,4 +570,12 @@ ActiveRecord::Schema.define(version: 20180604153605) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end

--- a/lib/tasks/vtul/compel.rake
+++ b/lib/tasks/vtul/compel.rake
@@ -1,0 +1,33 @@
+namespace :compel do
+  desc 'Create default roles.'
+  task add_roles: :environment do
+    ['admin', 'collection_admin', 'collection_user'].each do |role_name|
+      Role.find_or_create_by({name: role_name})
+      puts "Created role '#{role_name}'."
+    end
+  end
+
+  desc 'Upgrade users to admins.'
+  task upgrade_users: :environment do
+    admin_role = Role.find_by({name: 'admin'})
+
+    IO.foreach('admin_list.txt') do |email|
+      email = email.strip
+      user = User.find_by({email: email})
+
+      if !user.nil?
+        user.roles << admin_role
+        user.roles = user.roles.uniq
+        user.save!
+        puts "#{email} upgraded."
+      else
+        puts "#{email} user does not exist in system."
+      end
+    end
+  end
+
+  desc 'Create COMPEL default CollectionType.'
+  task create_default_collection_type: :environment do
+    Hyrax::CollectionType.find_or_create_by({title: "Collection", machine_id: "DefaultCompelCollection", description: "Default COMPEL collection type"})
+  end
+end

--- a/lib/tasks/vtul/compel.rake
+++ b/lib/tasks/vtul/compel.rake
@@ -29,5 +29,6 @@ namespace :compel do
   desc 'Create COMPEL default CollectionType.'
   task create_default_collection_type: :environment do
     Hyrax::CollectionType.find_or_create_by({title: "Collection", machine_id: "DefaultCompelCollection", description: "Default COMPEL collection type"})
+    puts "Created default COMPEL collection type."
   end
 end

--- a/lib/tasks/vtul/compel.rake
+++ b/lib/tasks/vtul/compel.rake
@@ -28,7 +28,12 @@ namespace :compel do
 
   desc 'Create COMPEL default CollectionType.'
   task create_default_collection_type: :environment do
-    Hyrax::CollectionType.find_or_create_by({title: "Collection", machine_id: "DefaultCompelCollection", description: "Default COMPEL collection type"})
-    puts "Created default COMPEL collection type."
+    default_collection_type_settings={title: "Collection", machine_id: "DefaultCompelCollection", description: "Default COMPEL collection type"}
+    if Hyrax::CollectionType.find_by(default_collection_type_settings)
+      puts "Default COMPEL collection type already exists."
+    else
+      Hyrax::CollectionType.create(default_collection_type_settings)
+      puts "Created default COMPEL collection type."
+    end
   end
 end


### PR DESCRIPTION
For this PR, I basically added the `hydra-role-management` gem and migrated related rake tasks. I also added one additional rake task for creating a default `CollectionType`.

To try it out:
* Run InstallScripts using `project_name: 'compel'` and `project_git_identifier: 'LIBTD-1340'`
* Bring up the application and sign up for an account
* Add that account's email to `admin_list.txt`
* Run the following to add Hydra management roles and upgrade your user to have admin privileges
  (similar to the previous binary_arts project)

```
  $ bin/rake compel:add_roles
  $ bin/rake compel:upgrade_users
```
* Run the following to create the default COMPEL collection type

```
  railsapps@compel:~/compel$ bin/rake compel:create_default_collection_type
```

* Login again and access your dashboard
 * Click on `Settings` >  `Collection Types`. You should see 'Collection' as one of the 'Current Collection Types'
 * Click on `Collections`. You should also be able to see the button "New Collection" and be able to create a simple collection without errors.

### Additional notes:
* There are errors when attempting to actually show/view a collection, but I expect these errors to be resolved once Work types have been added (see LIBTD-1335).
* Also, I'm not sure why it's happening, but I'm having to run `unset XDG_RUNTIME_DIR` to get past a spring error when I run commands like `bin/rails` or `bin/rake`:

```
$ bin/rake compel:upgrade_users
/usr/lib/ruby/2.3.0/fileutils.rb:254:in `mkdir': Permission denied @ dir_s_mkdir - /run/user/1000/spring-1001 (Errno::EACCES)
                                        from /usr/lib/ruby/2.3.0/fileutils.rb:254:in `fu_mkdir'
                                        from /usr/lib/ruby/2.3.0/fileutils.rb:228:in `block (2 levels) in mkdir_p'
                                        from /usr/lib/ruby/2.3.0/fileutils.rb:226:in `reverse_each'
                                        from /usr/lib/ruby/2.3.0/fileutils.rb:226:in `block in mkdir_p'
                                        from /usr/lib/ruby/2.3.0/fileutils.rb:211:in `each'
                                        from /usr/lib/ruby/2.3.0/fileutils.rb:211:in `mkdir_p'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/env.rb:40:in `tmp_path'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/env.rb:49:in `socket_path'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/env.rb:53:in `socket_name'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/client/run.rb:26:in `connect'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/client/run.rb:31:in `call'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/client/command.rb:7:in `call'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/client.rb:30:in `run'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/bin/spring:49:in `<top (required)>'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/binstub.rb:31:in `load'
                                        from /var/local/hydra/compel/vendor/bundle/ruby/2.3.0/gems/spring-2.0.2/lib/spring/binstub.rb:31:in `<top (required)>'
                                        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
                                        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
                                        from /var/local/hydra/compel/bin/spring:15:in `<top (required)>'
                                        from bin/rake:3:in `load'
                                        from bin/rake:3:in `<main>'
```