### PR TITLE
LIBTD-1405: SEAMUS Import Cleanup

### DIFF
--- a/lib/tasks/vtul/seamus.rake
+++ b/lib/tasks/vtul/seamus.rake
@@ -129,56 +129,40 @@ namespace :seamus do
   task cleanup_works: :environment do
     # Assumption for this task: If the depositor isn't lowercase, then the related creators and contributors are also not lowercase
     Composition.all.each do | comp |
-      if comp.depositor != comp.depositor.downcase
-        puts "Downcasing Composition depositor: " + comp.depositor + " for composition id: " + comp.id
-        comp.depositor = comp.depositor.downcase
-        comp.creator = comp.creator.map(&:downcase)  
-        comp.save!
-      end
-
-      pruned_description = comp.description.reject { |e| e.to_s.empty? }
-      if comp.description != pruned_description
-        puts "Pruning empty descriptions for composition id: " + comp.id
-        comp.description = pruned_description 
-        comp.save!
-      end
- 
-      pruned_score = comp.source.reject { |e| e.to_s.empty? }
-      if comp.source != pruned_score
-        puts "Pruning empty scores for composition id: " + comp.id
-        comp.source = pruned_score 
-        comp.save!
-      end
-
-      if comp.duration == ""
-        puts "Setting empty duration to nil for composition id: " + comp.id
-        comp.duration = nil
-        comp.save!
-      end
+      clean_up_work(comp)
     end
 
     Performance.all.each do | perf |
-      if perf.depositor != perf.depositor.downcase
-        puts "Downcasing Performance depositor: " + perf.depositor + " for performance id: " + perf.id
-        perf.depositor = perf.depositor.downcase
-        perf.creator = perf.creator.map(&:downcase)
-        perf.contributor = perf.contributor.map(&:downcase)
-        perf.save!
-      end
-
-      pruned_description = perf.description.reject { |e| e.to_s.empty? }
-      if perf.description != pruned_description
-        puts "Pruning empty descriptions for performance id: " + perf.id
-        perf.description = pruned_description 
-        perf.save!
-      end
-
-      if perf.duration == ""
-        puts "Setting empty duration to nil for performance id: " + perf.id
-        perf.duration = nil
-        perf.save!
-      end
+      clean_up_work(perf)
     end
   end
 
+  def clean_up_work(work)
+    if work.depositor != work.depositor.downcase
+      puts "Downcasing depositor: " + work.depositor + " for work id: " + work.id
+      work.depositor = work.depositor.downcase
+      work.creator = work.creator.map(&:downcase)
+      work.save!
+    end
+
+    pruned_description = work.description.reject { |e| e.to_s.empty? }
+    if work.description != pruned_description
+      puts "Pruning empty descriptions for work id: " + work.id
+      work.description = pruned_description
+      work.save!
+    end
+
+    pruned_score = work.source.reject { |e| e.to_s.empty? }
+    if work.source != pruned_score
+      puts "Pruning empty scores for work id: " + work.id
+      work.source = pruned_score
+      work.save!
+    end
+
+    if work.duration == ""
+      puts "Setting empty duration to nil for work id: " + work.id
+      work.duration = nil
+      work.save!
+    end
+  end
 end

--- a/lib/tasks/vtul/seamus.rake
+++ b/lib/tasks/vtul/seamus.rake
@@ -124,4 +124,61 @@ namespace :seamus do
       puts 'To run: bin/rake seamus:import_items["input.xml"]'
     end
   end
+
+  desc 'Cleanup for SEAMUS import. Must be run AFTER import_authors and import_items'
+  task cleanup_works: :environment do
+    # Assumption for this task: If the depositor isn't lowercase, then the related creators and contributors are also not lowercase
+    Composition.all.each do | comp |
+      if comp.depositor != comp.depositor.downcase
+        puts "Downcasing Composition depositor: " + comp.depositor + " for composition id: " + comp.id
+        comp.depositor = comp.depositor.downcase
+        comp.creator = comp.creator.map(&:downcase)  
+        comp.save!
+      end
+
+      pruned_description = comp.description.reject { |e| e.to_s.empty? }
+      if comp.description != pruned_description
+        puts "Pruning empty descriptions for composition id: " + comp.id
+        comp.description = pruned_description 
+        comp.save!
+      end
+ 
+      pruned_score = comp.source.reject { |e| e.to_s.empty? }
+      if comp.source != pruned_score
+        puts "Pruning empty scores for composition id: " + comp.id
+        comp.source = pruned_score 
+        comp.save!
+      end
+
+      if comp.duration == ""
+        puts "Setting empty duration to nil for composition id: " + comp.id
+        comp.duration = nil
+        comp.save!
+      end
+    end
+
+    Performance.all.each do | perf |
+      if perf.depositor != perf.depositor.downcase
+        puts "Downcasing Performance depositor: " + perf.depositor + " for performance id: " + perf.id
+        perf.depositor = perf.depositor.downcase
+        perf.creator = perf.creator.map(&:downcase)
+        perf.contributor = perf.contributor.map(&:downcase)
+        perf.save!
+      end
+
+      pruned_description = perf.description.reject { |e| e.to_s.empty? }
+      if perf.description != pruned_description
+        puts "Pruning empty descriptions for performance id: " + perf.id
+        perf.description = pruned_description 
+        perf.save!
+      end
+
+      if perf.duration == ""
+        puts "Setting empty duration to nil for performance id: " + perf.id
+        perf.duration = nil
+        perf.save!
+      end
+    end
+  end
+
 end

--- a/lib/tasks/vtul/seamus.rake
+++ b/lib/tasks/vtul/seamus.rake
@@ -129,19 +129,20 @@ namespace :seamus do
   task cleanup_works: :environment do
     # Assumption for this task: If the depositor isn't lowercase, then the related creators and contributors are also not lowercase
     Composition.all.each do | comp |
-      clean_up_work(comp)
+      cleanup_work(comp)
     end
 
     Performance.all.each do | perf |
-      clean_up_work(perf)
+      cleanup_work(perf)
     end
   end
 
-  def clean_up_work(work)
+  def cleanup_work(work)
     if work.depositor != work.depositor.downcase
       puts "Downcasing depositor: " + work.depositor + " for work id: " + work.id
       work.depositor = work.depositor.downcase
       work.creator = work.creator.map(&:downcase)
+      work.contributor = work.contributor.map(&:downcase)
       work.save!
     end
 


### PR DESCRIPTION
After running the rake tasks to import SEAMUS data (#10 ), run the following cleanup task:

```
bin/rake seamus:cleanup_works
```

This script will downcase emails and prune empty descriptions, scores, and durations from the recently imported SEAMUS data.

[Edit: Now, all SEAMUS users should have at least one associated work.]