### PR TITLE
Render images / videos larger on works show page

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -19,13 +19,10 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.universal_viewer? %>
             <div class="col-sm-12">
-              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+              <%= render 'representative_media', presenter: @presenter, viewer: @presenter.universal_viewer? %>
             </div>
-          <% end %>
           <div class="col-sm-3 text-center">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
             <%= render 'citations', presenter: @presenter %>
             <%= render 'social_media' %>
           </div>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,0 +1,21 @@
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%;max-height:500px;" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set) %>" />
+        Your browser does not support the video tag.
+      </video>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
+                  hyrax.download_path(file_set),
+                  data: { turbolinks: false, label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%;max-height:500px;" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set) %>" />
+        Your browser does not support the video tag.
+      </video>
+    </div>
+<% end %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -138,7 +138,7 @@ Hyrax.config do |config|
   #   * iiif_image_size_default
   #
   # Default is false
-  # config.iiif_image_server = false
+  config.iiif_image_server = true
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|


### PR DESCRIPTION
- enable universal viewer for images
- render audio/video larger
- remove file param from video src url as it causes 404 for some reason