### PR TITLE
LIBTD-1420: Add loofah sanitizer when displaying work description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,5 @@ gem 'pg'
 gem 'sidekiq'
 gem 'hydra-role-management'
 
+# Use loofah for HTML sanitization (XSS prevention)
+gem 'loofah', '~> 2.0', '>= 2.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -765,6 +765,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  loofah (~> 2.0, >= 2.0.3)
   pg
   puma (~> 3.7)
   rails (~> 5.1.6)

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -15,6 +15,7 @@ module HyraxHelper
       text = field
     end
 
+    text = Loofah.fragment(text).scrub!(:whitewash).to_s
     text = truncate(text, length: 100, separator: ' ', escape: false) if truncate
 
     # this block is only executed when a link is inserted;


### PR DESCRIPTION
You should be able to enter in descriptions for COMPEL works that contain questionable HTML tags. Upon displaying in the show pages, however, the helper function for displaying html_safe content has been modified to use the Loofah HTML sanitizer to whitewash known "unknown/unsafe/namespaced tags and their children and strips all node attributes" (according to https://github.com/flavorjones/loofah).

For example, the following:

```
<em>HI!</em> <script>...</script> <ul><li>hi</li></ul>
```

will be whitewashed of the questionable `<script>` tags.


NOTE: I've chosen the strictest setting -- :whitewash. This will take out the href in <a> tags. We can also try :prune if you want it less strict, but I thought to err on the side of caution.

Or, maybe we can make this configurable, if someone thinks it's necessary.