### PR TITLE
LIBTD-1425: Compel Seamus admin_set_id cleanup

### DIFF
--- a/lib/tasks/vtul/seamus.rake
+++ b/lib/tasks/vtul/seamus.rake
@@ -194,5 +194,11 @@ namespace :seamus do
       work.duration = nil
       work.save!
     end
+
+    if work.admin_set_id.nil?
+      puts "Setting admin_set_id to 'admin_set/default' for work id: " + work.id
+      work.admin_set_id = "admin_set/default"
+      work.save!
+    end
   end
 end


### PR DESCRIPTION
Addition to the seamus cleanup scripts to set all works to be part of the default admin set.

This assumes that the other import scripts have been run already. For example:

```
bin/rake seamus:import_authors["input.xml"] 
bin/rake seamus:import_items["input.xml"] 
bin/rake seamus:cleanup_users 
```

Then, you can run the modified task:
```
bin/rake seamus:cleanup_works 
```