### PR TITLE
LIBTD-1423 - Temporarily enable static files from /public folder in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,10 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # LIBTD-1423 - Temporarily enable static files from `/public` folder
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
This change was made so that the following commands to import SEAMUS data will render viewable profile pics in production:

```
sudo -u railsapps -i 
cd ~hydra/compel 
export RAILS_ENV=production 
bundle exec rails seamus:import_authors["input.xml"] 
```

Please note that after running this, a user should still be able to update his/her profile avatar from the application's dashboard. Also, there are no related changes to InstallScripts.