### PR TITLE
LIBTD-1442: Add Work Type to fields displayed in search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,7 +41,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 2
+    config.add_facet_field solr_name("human_readable_type", :facetable), limit: 2
     config.add_facet_field solr_name("resource_type", :facetable), limit: 5
     config.add_facet_field solr_name("creator", :facetable), limit: 5
     config.add_facet_field solr_name("contributor", :facetable), limit: 5
@@ -66,6 +66,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
+    config.add_index_field solr_name("human_readable_type", :stored_searchable), link_to_search: solr_name("human_readable_type", :facetable)
     config.add_index_field solr_name("creator", :stored_searchable),link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("contributor", :stored_searchable), link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("venue", :stored_searchable), link_to_search: solr_name("venue", :facetable)

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -5,6 +5,7 @@ en:
       fields:
         facet:
           based_near_label_sim: Location
+          human_readable_type_sim: Type
           creator_sim: Composer
           contributor_sim: Performer
           venue_sim: Venue
@@ -19,6 +20,7 @@ en:
           duration_sim: Duration
         index:
           based_near_tesim: Location
+          human_readable_type_tesim: Type
           contributor_tesim: Contributor
           creator_tesim: Composer
           contributor_tesim: Performer


### PR DESCRIPTION
JIRA Ticket: LIBTD-1442: https://webapps.es.vt.edu/jira/browse/LIBTD-1442

A human_readable_type solr field is added into the index fields in catalog_controller.rb so that the type of a work or a collection can be displayed in the search results.

The name of the field is changed and reflected in config/locale/hyrax.en.yml for human_readable_type.

To test, @shabububu please base off the LIBTD-1442 branch of compel project.