### PR TITLE
LIBTD-1424: HTML Sanitizer on Input Fields Prior to Entering Data to DB or Fedora

### DIFF
--- a/app/renderers/hyrax/renderers/markdown_generated_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/markdown_generated_attribute_renderer.rb
@@ -1,0 +1,14 @@
+module Hyrax
+  module Renderers
+    class MarkdownGeneratedAttributeRenderer < AttributeRenderer
+
+      private
+
+        def li_value(value)
+          # Note that html_safe is applied to the value elsewhere in the
+          # inherited AttributeRenderer
+          value
+        end
+    end
+  end
+end

--- a/app/renderers/hyrax/renderers/markdown_generated_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/markdown_generated_attribute_renderer.rb
@@ -1,13 +1,12 @@
 module Hyrax
   module Renderers
     class MarkdownGeneratedAttributeRenderer < AttributeRenderer
+      include HyraxHelper 
 
       private
 
         def li_value(value)
-          # Note that html_safe is applied to the value elsewhere in the
-          # inherited AttributeRenderer
-          value
+          link_to_html(value)
         end
     end
   end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -8,7 +8,7 @@
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:medium, html_dl: true) %>
 <%= presenter.attribute_to_html(:source, render_as: :external_link, html_dl: true) %>
-<%= presenter.attribute_to_html(:technical_specs, render_as: :markdown_generated) %>
-<%= presenter.attribute_to_html(:program_notes, render_as: :markdown_generated) %>
+<%= presenter.attribute_to_html(:technical_specs, render_as: :markdown_generated, html_dl: true) %>
+<%= presenter.attribute_to_html(:program_notes, render_as: :markdown_generated, html_dl: true) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true) %>
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -8,7 +8,7 @@
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:medium, html_dl: true) %>
 <%= presenter.attribute_to_html(:source, render_as: :external_link, html_dl: true) %>
-<%= presenter.attribute_to_html(:technical_specs, html_dl: true) %>
-<%= presenter.attribute_to_html(:program_notes, html_dl: true) %>
+<%= presenter.attribute_to_html(:technical_specs, render_as: :markdown_generated) %>
+<%= presenter.attribute_to_html(:program_notes, render_as: :markdown_generated) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true) %>
 

--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -15,7 +15,7 @@
   <div class="form-group">
     <%= f.label :personal_statement, 'Personal statement', class: 'col-xs-4 control-label' %>
     <div class="col-xs-8">
-       <%= f.text_area :personal_statement, class: "form-control" %>
+       <%= f.text_area :personal_statement, class: "tinymce form-control" %>
     </div>
   </div><!-- .form-group -->
   <%# COMPEL Modification: end %>

--- a/app/views/hyrax/dashboard/profiles/show.html.erb
+++ b/app/views/hyrax/dashboard/profiles/show.html.erb
@@ -15,7 +15,7 @@
       <div class="list-group col-md-5 col-sm-8">
 
         <%# COMPEL Modification: begin %>
-        <%= @user.personal_statement.html_safe if @user.personal_statement %>
+        <%= link_to_html(@user.personal_statement) if @user.personal_statement %>
         <%# COMPEL Modification: end %>
 
         <%= render "hyrax/users/vitals", user: @user %>

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -1,0 +1,37 @@
+<%# Modified from Hyrax Gem 2.1.0 %>
+
+<%= csrf_meta_tag %>
+<meta charset="utf-8" />
+<%# Only display meta tag, which enables creation of the ActionCable
+consumer, when realtime notifications are enabled and the user is
+signed in %>
+<% if Hyrax.config.realtime_notifications? && signed_in? %>
+    <%= tag :meta, name: 'current-user', data: { user_key: current_user.user_key } %>
+<% end %>
+<!-- added for use on small devices like phones -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+<link rel="resourcesync" href="<%= hyrax.capability_list_url %>" />
+
+<!-- Twitter card metadata -->
+<%= yield :twitter_meta %>
+<!-- Google Scholar metadata -->
+<%= yield :gscholar_meta %>
+
+<title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
+
+<!-- application css -->
+<%= stylesheet_link_tag 'application' %>
+
+<!-- application js -->
+<%= javascript_include_tag 'application' %>
+<%= render 'shared/appearance_styles' %>
+
+<%# COMPEL Modification: begin %>
+<%= tinymce_assets if (can? :update, ContentBlock) || (can? :edit, current_user) %>
+<%# COMPEL Modification: end %>
+
+<!-- Google Analytics -->
+<%= render partial: '/ga', formats: [:html] %>
+
+<!-- for extras, e.g., a favicon -->
+<%= render partial: '/head_tag_extras', formats: [:html] %>

--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,7 +1,0 @@
-<%# Modified from Hyrax Gem 2.1.0 - use tinymce for input %>
-
-<% if f.object.multiple? key %>
-  <%= f.input :description, as: :multi_value, input_html: { class: 'tinymce', rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
-<% else %>
-  <%= f.input :description, as: :text, input_html: { class: 'tinymce', rows: '14' }, required: f.object.required?(key) %>
-<% end %>

--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,0 +1,7 @@
+<%# Modified from Hyrax Gem 2.1.0 - use tinymce for input %>
+
+<% if f.object.multiple? key %>
+  <%= f.input :description, as: :multi_value, input_html: { class: 'tinymce', rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :description, as: :text, input_html: { class: 'tinymce', rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/edit_fields/_program_notes.html.erb
+++ b/app/views/records/edit_fields/_program_notes.html.erb
@@ -1,1 +1,1 @@
-<%= f.input :program_notes, as: :text, input_html: { rows: '14' }, required: false %>
+<%= f.input :program_notes, as: :text, input_html: { class: 'tinymce', rows: '14' }, required: false %>

--- a/app/views/records/edit_fields/_technical_specs.html.erb
+++ b/app/views/records/edit_fields/_technical_specs.html.erb
@@ -1,1 +1,1 @@
-<%= f.input :technical_specs, as: :text, input_html: { rows: '14' }, required: false %>
+<%= f.input :technical_specs, as: :text, input_html: { class: 'tinymce', rows: '14' }, required: false %>


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1424

# What does this Pull Request do?
For this PR, I've added tinymce for the form input on a work's description, program notes, and technical specs. The user profile's personal statement and collection's description has been modified as well. This is one step to add "due diligence" security to COMPEL, while also allowing the user some freedom to stylize their works and profile.

See the Jira ticket for more information.

# What are the changes?
For this PR, I've added tinymce for the form input on a work's description, program notes, and technical specs. The user profile's personal statement and collection's description has been modified as well. I carried over and modified the `_head_tag_content.html.erb` from the Hyrax 2.1.0 gem to allow for using tinymce without administrative privileges.

# How should this be tested?

One way of testing this out would be to create both a Performance work and Composition work, adding stylized content for the modified fields.   Also, attempt modifying your user's personal statement. Finally, create a collection with a description. If the styles come out as expected and potentially malicious code is not allowed (e.g. <script>...</script>), then it should be working as expected. You may need to use the rails and fedora consoles to see if they are actually stored as expected. [Edit: One clarification, the potentially malicious tags should still be visible, but not rendered as html]

# Additional Notes:
* I'm not a security expert, but this seemed like one approach to adding security without detracting from user experience. This should be considered while reviewing this PR.
* Use the LIBTD-1424 branch for testing

# Interested parties
@whunter @tingtingjh 