### PR TITLE
LIBTD-1441: Put Composition into "Relationships" section at Performance show page

### DIFF
--- a/app/views/hyrax/base/_performance_composition_info.html.erb
+++ b/app/views/hyrax/base/_performance_composition_info.html.erb
@@ -1,11 +1,7 @@
-<% if !composition.nil? %>
-  <h2>Composition</h2>
-  <div>
-    <strong>Performance of:</strong> <%= link_to "#{composition.title.first}", "/concern/compositions/#{composition.id}" %>
-  </div>
-  <div>
-    <strong>Composed by:</strong> <span class="composition-composer"><%= link_to composition.creator.first, composer_link %></span>
-  </div>
-  <br />
-<% end %>
-
+<dt>Associated Composition:</dt>
+<dd>
+  <strong>Performance of:</strong> <%= link_to "#{composition.title.first}", "/concern/compositions/#{composition.id}" %>
+</dd>
+<dd>
+  <strong>Composed by:</strong> <span class="composition-composer"><%= link_to composition.creator.first, composer_link %></span>
+</dd>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -1,0 +1,20 @@
+<%# COMPEL adds composition relationship -%>
+<% unless @composition.nil? %>
+  <%= render("performance_composition_info", presenter: @presenter,
+             composition: @composition, composer_link: @composer_link) if controller_name == "performances" %>
+<% end %>
+<%# Render presenters which aren't specified in the 'presenter_types' %>
+<% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
+  <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
+<% end %>
+
+<%# Render grouped presenters. Show rows if there are any items of that type %>
+<% presenter.presenter_types.each do |type| %>
+  <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
+    <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
+  <% end %>
+<% end %>
+
+<% if current_user %>
+<%= presenter.attribute_to_html(:admin_set, render_as: :faceted, html_dl: true) %>
+<% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,5 +1,4 @@
 <%# Modified from Hyrax 2.1.0 Gem %>
-<%# - Adding rendering of performance_composition_info %>
 <%# - Adding rendering of performances %>
 
 <% provide :page_title, @presenter.page_title %>
@@ -27,11 +26,6 @@
             <%= render 'social_media' %>
           </div>
           <div class="col-sm-9">
-            <%# COMPEL-specific rendering: begin %>
-            <%= render("performance_composition_info", presenter: @presenter,
-                       composition: @composition, composer_link: @composer_link) if controller_name == "performances" %>
-            <%# COMPEL-specific rendering: end %>
-
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>
           </div>


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1441 (:star:)

# What does this Pull Request do? (:star:)
Resolve the problem that "composition" relationship displayed on the performance show page would mislead users as a Composition work.

# What's the changes? (:star:)
Move the "composition" relationship to "Relationships" section in the performance show page. 

# How should this be tested?

A description of what steps someone could take to:
* Use the LIBTD-1441 branch for testing
* Create a composition work first. 
* Create a performance work associated with the created composition.
* The composition relationship is displayed in the "Relationships" section.
* Create a collection then add the performance work into the collection. (optional)
* Go to performance show page to see both relationships. (optional)

# Additional Notes:
Need to create another ticket to make similar changes for Composition show page.

# Interested parties
@shabububu 

(:star:) Required fields
