### PR TITLE
make profile pic take up available space in sidebar

### DIFF
--- a/app/assets/stylesheets/vtul/dashboard.scss
+++ b/app/assets/stylesheets/vtul/dashboard.scss
@@ -1,0 +1,14 @@
+.sidebar .profile {
+  padding: 0;
+  .profile-image {
+    img {
+      width: 100%;
+    }
+  }
+}
+@media(min-width: 993px) {
+  .dashboard .sidebar {
+    padding-top: 50px;
+  }
+}
+

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -1,0 +1,20 @@
+<% menu = Hyrax::MenuPresenter.new(self) %>
+<div class="sidebar-toggle"><span class="fa fa-chevron-circle-right"></span></div>
+<ul class="nav nav-pills nav-stacked">
+  <li>
+    <div class="profile">
+      <div class="profile-image">
+        <%= image_tag current_user.avatar.url(:medium) if current_user.avatar.present? %>
+      </div>
+      <div class="profile-data">
+        <div class="profile-data-name"><%= current_user.name %></div>
+      </div>
+    </div>
+  </li>
+
+  <%= render 'hyrax/dashboard/sidebar/activity', menu: menu %>
+  <%= render 'hyrax/dashboard/sidebar/repository_content', menu: menu %>
+  <%= render 'hyrax/dashboard/sidebar/tasks', menu: menu %>
+  <%= render 'hyrax/dashboard/sidebar/configuration', menu: menu %>
+</ul>
+


### PR DESCRIPTION
**Make user's profile pic more prominent.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1461) (:star:)

# What does this Pull Request do? (:star:)
Makes user's profile pic take up 100% of width in left sidebar. Height determined by the img size.

# What's the changes? (:star:)
Makes user's profile pic take up 100% of width in left sidebar. Height determined by the img size.

# How should this be tested?
* Log in or create account and upload a profile pic from the Edit Profile page.
* Check that the image takes up all of the width of the left sidebar

# Additional Notes:
* branch: `profile_img_fix`

(:star:) Required fields
