### PR TITLE
LIBTD-1464: Remove admin set functionality

### DIFF
--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -1,0 +1,16 @@
+<%# Render presenters which aren't specified in the 'presenter_types' %>
+<% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
+  <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
+<% end %>
+
+<%# Render grouped presenters. Show rows if there are any items of that type %>
+<% presenter.presenter_types.each do |type| %>
+  <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
+    <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
+  <% end %>
+<% end %>
+
+<%# COMPEL removes administrative set functionality -%>
+<% if Flipflop.assign_admin_set? %>
+  <%= presenter.attribute_to_html(:admin_set, render_as: :faceted, html_dl: true) %>
+<% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,0 +1,2 @@
+assign_admin_set:
+  enabled: false


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1464 (:star:)

# What does this Pull Request do? (:star:)
Hyrax displays references to admin sets by default. This PR turns off this feature by COMPEL requirement.

# What's the changes? (:star:)
* Toggle this feature off by setting it in feature_config_path which is config/features.yml.
* Changes made in app/views/hyrax/base/_relationships_parent_rows.html.erb makes sure that if this feature is indeed flipped off, not to display admin set relationship.

# How should this be tested?
* Create a performance or composition work. Then check if the default admin set is not displayed in the "Relationships" section.
* Sign in as an admin user, go to dashboard -> Settings -> Features, to check if the assign admin set feature is disabled.

# Additional Notes:
* Testing branch: LIBTD-1464
* assign_admin_set should be set as boolean false instead of string false which is deviated from Samvera https://github.com/samvera/hyrax
* Changes made in config might require a restart of your virtual machine

# Interested parties
@shabububu 
(:star:) Required fields
