### PR TITLE
LIBTD-1471: Turn off config that requires file upload upon work creation

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -118,7 +118,7 @@ Hyrax.config do |config|
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?
   # The default is true.
-  # config.work_requires_files = true
+  config.work_requires_files = false
 
   # How many rows of items should appear on the work show view?
   # The default is 10


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1471 (:star:)

# What does this Pull Request do? (:star:)
By default of a Hyrax 2 based application, work creation requires file upload. This PR turns off this option off so that file upload is not required at the work creation page.

# What's the changes? (:star:)
* Changes the configuration variable "work_requires_files" to false in config/initializers/hyrax.rb

# How should this be tested?

* Test branch 1471
* Try to create a composition or performance work
* Check to see if the "Add Files" are taken away from the "save work" requirement list
* Check to see if a work can be saved without uploading a file

# Interested parties
@pmather 

(:star:) Required fields
