### PR TITLE
remove borders from Item thumbnails

### DIFF
--- a/app/assets/stylesheets/vtul/works_show.scss
+++ b/app/assets/stylesheets/vtul/works_show.scss
@@ -1,0 +1,4 @@
+.related-files .thumbnail {
+  border: none;
+  background-color: transparent;
+}

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class= "explore_section">
     <div class="explore_photo">
-      <%= image_tag('vtul/bug_1', alt: 'digital music performance') %>
+      <%= image_tag('vtul/bug_1.jpg', alt: 'digital music performance') %>
     </div>
     <div class="explore_photo_text">Introducing a framework that offers storage, retrieval, sorting, dynamic curation, and reproducibility of the electroacoustic compositions written for a live performer and technology</div>
   </div>		


### PR DESCRIPTION
**Re-style thumbnail images to have no border.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1463) (:star:)

# What does this Pull Request do? (:star:)
Removes border from thumbnail images. It's a very, very minor change.

# What's the changes? (:star:)
Removes border from thumbnail images. It's a very, very minor change.

Example:
Changes thumbnails from this:
<img width="667" alt="screen shot 2018-07-31 at 1 45 40 pm" src="https://user-images.githubusercontent.com/1202435/43478437-e426a05a-94cb-11e8-8d9c-5ea5b30bde2b.png">

To this:
<img width="706" alt="screen shot 2018-07-31 at 1 41 56 pm" src="https://user-images.githubusercontent.com/1202435/43478455-ed1e8948-94cb-11e8-9b90-3e81e012f260.png">


# How should this be tested?

* Create a performance or composition
* Add one or more images
* Ensure that the thumbnails in the items section do not have borders

# Additional Notes:

* branch: search_img_edit
