### PR TITLE
Upgrade sprockets due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -701,7 +701,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)
@@ -786,4 +786,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.2
+   1.16.3


### PR DESCRIPTION
# What does this Pull Request do?

Upgrade the current version of the `sprockets` Gem due to [CVE-2018-3760](https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k)

# What's the changes?

The version of the `sprockets` Gem in `Gemfile.lock` is upgraded from version 3.7.1 to 3.7.2.

# How should this be tested?

Deploy the `compel` application in `production` mode and check that it is running correctly.

# Interested parties
@whunter 

