### PR TITLE
Make tinyMCE thingy work for descriptions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,4 +22,4 @@
 
 //= require_tree .
 //= require hyrax
-
+//= require vtul/multi_tinymce

--- a/app/assets/javascripts/vtul/multi_tinymce.js
+++ b/app/assets/javascripts/vtul/multi_tinymce.js
@@ -17,8 +17,8 @@ Blacklight.onLoad(function() {
     $newEditorLi.append($fieldControls);
     window.tinyMCE.init({
       selector: 'textarea#' + $newTextArea.attr('id'),
-      width: 542,
-      height: 293,
+      width: "100%",
+      height: 294,
       init_instance_callback: function (editor) {
         console.log($newEditorLi.find('div.mce-tinymce.mce-container.mce-panel'));
         $newEditorLi.find('div.mce-tinymce.mce-container.mce-panel').show();

--- a/app/assets/javascripts/vtul/multi_tinymce.js
+++ b/app/assets/javascripts/vtul/multi_tinymce.js
@@ -1,15 +1,16 @@
 var tinymceDescriptionNumber = 0;
 var compositionDiv = 'div.base-terms > div.composition_description';
 var performanceDiv = 'div.base-terms > div.performance_description';
+var collectionDiv = 'div#base-terms > div.collection_description';
 var addSelector = 'button.btn-link.add';
-var addButton = compositionDiv + ' ' + addSelector + ', ' + performanceDiv + ' ' + addSelector;
+var addButton = compositionDiv + ' ' + addSelector + ', ' + performanceDiv + ' ' + addSelector + ', ' + collectionDiv + ' ' + addSelector;
 var editorSelector = 'ul.listing > li.field-wrapper.input-group';
-var editors = compositionDiv + ' ' + editorSelector + ', ' + performanceDiv + ' ' + editorSelector;
+var editors = compositionDiv + ' ' + editorSelector + ', ' + performanceDiv + ' ' + editorSelector + ', ' + collectionDiv + ' ' + editorSelector;
 
 Blacklight.onLoad(function() {
   $(document).on('click', addButton, function(){
     var $newEditorLi = $(editors).last();
-    var $newTextArea = $newEditorLi.find('textarea.composition_description, textarea.performance_description');
+    var $newTextArea = $newEditorLi.find('textarea.collection_description, textarea.composition_description, textarea.performance_description');
     var $fieldControls = $newEditorLi.find('span.input-group-btn.field-controls');
     $newEditorLi.empty();
     $newTextArea.attr('id', 'description_' + tinymceDescriptionNumber++);

--- a/app/assets/javascripts/vtul/multi_tinymce.js
+++ b/app/assets/javascripts/vtul/multi_tinymce.js
@@ -1,15 +1,18 @@
 var tinymceDescriptionNumber = 0;
-var descriptionDiv = 'div.base-terms > div.composition_description';
-var addButton = descriptionDiv + ' button.btn-link.add';
-var editors = descriptionDiv + ' ul.listing > li.field-wrapper.input-group';
+var compositionDiv = 'div.base-terms > div.composition_description';
+var performanceDiv = 'div.base-terms > div.performance_description';
+var addSelector = 'button.btn-link.add';
+var addButton = compositionDiv + ' ' + addSelector + ', ' + performanceDiv + ' ' + addSelector;
+var editorSelector = 'ul.listing > li.field-wrapper.input-group';
+var editors = compositionDiv + ' ' + editorSelector + ', ' + performanceDiv + ' ' + editorSelector;
 
 Blacklight.onLoad(function() {
   $(document).on('click', addButton, function(){
     var $newEditorLi = $(editors).last();
-    var $newTextArea = $newEditorLi.find('textarea.composition_description');
+    var $newTextArea = $newEditorLi.find('textarea.composition_description, textarea.performance_description');
     var $fieldControls = $newEditorLi.find('span.input-group-btn.field-controls');
     $newEditorLi.empty();
-    $newTextArea.attr('id', 'composition_description_' + tinymceDescriptionNumber++);
+    $newTextArea.attr('id', 'description_' + tinymceDescriptionNumber++);
     $newEditorLi.append($newTextArea);
     $newEditorLi.append($fieldControls);
     window.tinyMCE.init({

--- a/app/assets/javascripts/vtul/multi_tinymce.js
+++ b/app/assets/javascripts/vtul/multi_tinymce.js
@@ -1,0 +1,26 @@
+var tinymceDescriptionNumber = 0;
+var descriptionDiv = 'div.base-terms > div.composition_description';
+var addButton = descriptionDiv + ' button.btn-link.add';
+var editors = descriptionDiv + ' ul.listing > li.field-wrapper.input-group';
+
+Blacklight.onLoad(function() {
+  $(document).on('click', addButton, function(){
+    var $newEditorLi = $(editors).last();
+    var $newTextArea = $newEditorLi.find('textarea.composition_description');
+    var $fieldControls = $newEditorLi.find('span.input-group-btn.field-controls');
+    $newEditorLi.empty();
+    $newTextArea.attr('id', 'composition_description_' + tinymceDescriptionNumber++);
+    $newEditorLi.append($newTextArea);
+    $newEditorLi.append($fieldControls);
+    window.tinyMCE.init({
+      selector: 'textarea#' + $newTextArea.attr('id'),
+      width: 542,
+      height: 293,
+      init_instance_callback: function (editor) {
+        console.log($newEditorLi.find('div.mce-tinymce.mce-container.mce-panel'));
+        $newEditorLi.find('div.mce-tinymce.mce-container.mce-panel').show();
+      }
+    });
+  });  
+
+});

--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,0 +1,7 @@
+<%# Modified from Hyrax Gem 2.1.0 - use tinymce for input %>
+
+<% if f.object.multiple? key %>
+  <%= f.input :description, as: :multi_value, input_html: { class: 'tinymce', rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :description, as: :text, input_html: { class: 'tinymce', rows: '14' }, required: f.object.required?(key) %>
+<% end %>


### PR DESCRIPTION
**Makes tinyMCE editor work for composition description which is multi-valued**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1479) (:star:)

# What does this Pull Request do? (:star:)
Addresses bug in tinyMCE initialization in multi-valued fields

# What's the changes? (:star:)
Addresses bug in tinyMCE initialization in multi-valued fields

# How should this be tested?
* Create a composition with multiple entries in description and ensure it works

# Additional Notes:
* branch: LIBTD-1479

# Interested parties
@tingtingjh @shabububu 

(:star:) Required fields
