### PR TITLE
Add reCAPTCHA to the account creation form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem 'riiif', '~> 1.1'
 gem 'pg'
 gem 'sidekiq'
 gem 'hydra-role-management'
+gem "recaptcha"
 
 # Use loofah for HTML sanitization (XSS prevention)
 gem 'loofah', '~> 2.0', '>= 2.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,6 +588,8 @@ GEM
       rdf (>= 2.2, < 4.0)
     rdf-xsd (2.2.1)
       rdf (>= 2.2, < 4.0)
+    recaptcha (4.12.0)
+      json
     redic (1.5.0)
       hiredis
     redis (4.0.1)
@@ -769,6 +771,7 @@ DEPENDENCIES
   pg
   puma (~> 3.7)
   rails (~> 5.1.6)
+  recaptcha
   riiif (~> 1.1)
   rsolr (>= 1.0)
   rspec-rails
@@ -786,4 +789,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/app/assets/stylesheets/vtul/devise.scss
+++ b/app/assets/stylesheets/vtul/devise.scss
@@ -1,0 +1,6 @@
+.actions {
+  .g-recaptcha {
+    margin-top: 35px;
+    margin-bottom: 15px;
+  }
+}

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+class Devise::RegistrationsController < DeviseController
+  prepend_before_action :require_no_authentication, only: [:new, :create, :cancel]
+  prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy]
+  prepend_before_action :set_minimum_password_length, only: [:new, :edit]
+  prepend_before_action :check_captcha, only: [:create]
+
+  # GET /resource/sign_up
+  def new
+    build_resource
+    yield resource if block_given?
+    respond_with resource
+  end
+
+  # POST /resource
+  def create
+    build_resource(sign_up_params)
+
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+      if resource.active_for_authentication?
+        set_flash_message! :notice, :signed_up
+        sign_up(resource_name, resource)
+        respond_with resource, location: after_sign_up_path_for(resource)
+      else
+        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+        expire_data_after_sign_in!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  # GET /resource/edit
+  def edit
+    render :edit
+  end
+
+  # PUT /resource
+  # We need to use a copy of the resource because we don't want to change
+  # the current user in place.
+  def update
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    resource_updated = update_resource(resource, account_update_params)
+    yield resource if block_given?
+    if resource_updated
+      if is_flashing_format?
+        flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
+          :update_needs_confirmation : :updated
+        set_flash_message :notice, flash_key
+      end
+      bypass_sign_in resource, scope: resource_name
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  # DELETE /resource
+  def destroy
+    resource.destroy
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message! :notice, :destroyed
+    yield resource if block_given?
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+  end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  def cancel
+    expire_data_after_sign_in!
+    redirect_to new_registration_path(resource_name)
+  end
+
+  protected
+
+  def check_captcha
+    unless verify_recaptcha
+      self.resource = resource_class.new
+      flash.now[:alert] = "Please check the reCAPTCHA box to submit" 
+      respond_with_navigational(resource) { render :new }
+    end
+  end
+
+  def update_needs_confirmation?(resource, previous)
+    resource.respond_to?(:pending_reconfirmation?) &&
+      resource.pending_reconfirmation? &&
+      previous != resource.unconfirmed_email
+  end
+
+  # By default we want to require a password checks on update.
+  # You can overwrite this method in your own RegistrationsController.
+  def update_resource(resource, params)
+    resource.update_with_password(params)
+  end
+
+  # Build a devise resource passing in the session. Useful to move
+  # temporary session data to the newly created user.
+  def build_resource(hash = {})
+    self.resource = resource_class.new_with_session(hash, session)
+  end
+
+  # Signs in a user on sign up. You can overwrite this method in your own
+  # RegistrationsController.
+  def sign_up(resource_name, resource)
+    sign_in(resource_name, resource)
+  end
+
+  # The path used after sign up. You need to overwrite this method
+  # in your own RegistrationsController.
+  def after_sign_up_path_for(resource)
+    after_sign_in_path_for(resource)
+  end
+
+  # The path used after sign up for inactive accounts. You need to overwrite
+  # this method in your own RegistrationsController.
+  def after_inactive_sign_up_path_for(resource)
+    scope = Devise::Mapping.find_scope!(resource)
+    router_name = Devise.mappings[scope].router_name
+    context = router_name ? send(router_name) : self
+    context.respond_to?(:root_path) ? context.root_path : "/"
+  end
+
+  # The default url to be used after updating a resource. You need to overwrite
+  # this method in your own RegistrationsController.
+  def after_update_path_for(resource)
+    signed_in_root_path(resource)
+  end
+
+  # Authenticates the current scope and gets the current resource from the session.
+  def authenticate_scope!
+    send(:"authenticate_#{resource_name}!", force: true)
+    self.resource = send(:"current_#{resource_name}")
+  end
+
+  def sign_up_params
+    devise_parameter_sanitizer.sanitize(:sign_up)
+  end
+
+  def account_update_params
+    devise_parameter_sanitizer.sanitize(:account_update)
+  end
+
+  def translation_scope
+    'devise.registrations'
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,30 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= recaptcha_tags %>
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,6 @@
+Recaptcha.configure do |config|
+  config.site_key  = Rails.application.secrets[:recaptcha][:site_key]
+  config.secret_key = Rails.application.secrets[:recaptcha][:secret_key]
+  # Uncomment the following line if you are using a proxy server:
+  # config.proxy = 'http://myproxy.com.au:8080'
+end


### PR DESCRIPTION
**Add reCAPTCHA to the account creation form so we don't end up with a bunch of evil robots in our user table.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1446) (:star:)

# What does this Pull Request do? (:star:)
* Adds recaptcha gem. 
* Uses it to populate the registration form with a recaptcha thingy. 
* Then validates the response in the registrations controller

# What's the changes? (:star:)
* Adds recaptcha gem. 
* Uses it to populate the registration form with a recaptcha thingy. 
* Then validates the response in the registrations controller

# How should this be tested?
* Put site_key and secret_key (new) in site_secrets.yml before provisioning. I'll provide those values to you.
* Make sure that you can successfully register a user account if you do click the captcha thingy.
* Make sure that there is an error message and no account is created if you DON'T click the captcha thingy.

# Additional Notes:
* compel application branch: `captcha_acct_creation`
* Installscripts branch: `captcha_acct_creation`

# Interested parties
@tingtingjh 

(:star:) Required fields
