### PR TITLE
Speed up loading Performance new/edit form

### DIFF
--- a/app/models/composition_search_builder.rb
+++ b/app/models/composition_search_builder.rb
@@ -1,0 +1,14 @@
+class CompositionSearchBuilder < Blacklight::SearchBuilder
+  include Blacklight::Solr::SearchBuilderBehavior
+  include Hydra::AccessControlsEnforcement
+  include Hyrax::SearchFilters
+
+  self.default_processor_chain = [:compositions]
+
+  def compositions(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << "{!field f=has_model_ssim v=Composition}"
+    solr_parameters[:rows] = 10000
+  end
+
+end

--- a/app/services/compositions_service.rb
+++ b/app/services/compositions_service.rb
@@ -1,16 +1,18 @@
 module CompositionsService
-  mattr_accessor :authority
-  self.authority = Composition
 
   def self.select_all_options
-    authority.all.map do |element|
-      [label(element.id), element.id]
+    repository = CatalogController.new.repository
+    builder = CompositionSearchBuilder.new(repository)
+    response = repository.search(builder)
+    if response.documents.respond_to?("map")
+      response.documents.map do |composition|
+        [label(composition), composition.id]
+      end
     end
   end
 
-  def self.label(id)
-    comp = authority.find(id)
-    "#{comp.title.first} | #{comp.creator.first}"
+  def self.label(composition)
+    "#{composition.title.first} | #{composition.creator.first}"
   end
 
 end


### PR DESCRIPTION
**Speed up query that populates the "composition_id" field in the Performance new/edit form.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1530) (:star:)

# What does this Pull Request do? (:star:)
When a user tries to create a Performance record the form takes forever to load because the service that populates it is pulling every Composition record from Fedora. (It actually loops through all of them and then does a query for each individual one again). With almost 500 Composition records this takes a really long time. This PR changes the service to pull all of the Composition records from solr instead.

# What's the changes? (:star:)
* Creates a custom search builder that returns all Composition records.
* Modifies the composition_service to use the solr search and then create the array to populate the form field.

# How should this be tested?
* Use the rake tasks to create all of the User, Composition, and Performance records.
* Check that the form page loads in a reasonable time and doesn't hang when creating a Performance record
* Check that the Composition drop-down is populated with all of the Composition records
* Attach a Composition to the Performance being created
* Make sure that the selected Composition is present on the Performance show page

# Additional Notes:
* branch: `composition_query`


# Interested parties
@shabububu 

(:star:) Required fields
