### PR TITLE
No need to define default collection types as they are defined from H…

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,11 +17,6 @@ module Compel
 
     # Overrides
     config.to_prepare do
-
-      # TEMP Solution for LIBTD-1418
-      Hyrax::CollectionType.const_set('USER_COLLECTION_DEFAULT_TITLE','User Collection')
-      Hyrax::CollectionType.const_set('ADMIN_SET_DEFAULT_TITLE','Admin Set')
-
       Hyrax::HomepageController.prepend Hyrax::HomepageControllerOverride
       Hyrax::Dashboard::ProfilesController.prepend Hyrax::Dashboard::ProfilesControllerOverride
       Hyrax::PagesController.prepend Hyrax::PagesControllerOverride


### PR DESCRIPTION
…yrax2.1 gem

**No need to re-define USER_COLLECTION_DEFAULT_TITLE and ADMIN_SET_DEFAULT_TITLE as these default collection types have been defined in Hyrax2.1.0 gem**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1419) (:star:)

* Other Relevant Links (This is related to JIRA Ticket https://webapps.es.vt.edu/jira/browse/LIBTD-1418 as previously there was a temporary fix on properly setting up collection types issue.)

# What does this Pull Request do? (:star:)
Previously, there was a temporary fix to define collection types in config/application.rb so to set up the default collection types. Now this becomes unnecessary(duplication) as these types have already been defined in config/locales/hyrax.en.yml from hydrax2.1.0 gem.

# What's the changes? (:star:)
Remove the definitions of default collection types in config/application.rb

# How should this be tested?

* Log in as admin user and go to dashboard --> Configuration --> Settings --> Collection Types
* Should be able to see "User Collection" and "Admin Set" collection types.
* Click on Repository Contents --> Collections --> New Collection
* Should be able to create both types of collections.
* Log in as non-admin user, go to dashboard and click on "New Collection"
* Should be able to create a "User Collection" type of collection.


# Additional Notes:

* branch "remove_collection_type_definitions"

# Interested parties
Tag (@whunter ) interested parties

(:star:) Required fields
