### PR TITLE
Address security vulnerabilities in gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     connection_pool (2.2.2)
     crass (1.0.4)
     daemons (1.2.6)
@@ -441,7 +441,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -470,7 +470,7 @@ GEM
     noid-rails (3.0.0)
       actionpack (>= 5.0.0, < 6)
       noid (~> 0.9)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
     oauth2 (1.4.0)
@@ -501,7 +501,7 @@ GEM
       nokogiri (~> 1.6)
       rails (~> 5.0)
       rdf
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.1)
       rack
     rack-test (1.0.0)
@@ -635,7 +635,7 @@ GEM
       oauth2
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.5.6)
@@ -703,7 +703,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)
@@ -789,4 +789,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.4
+   1.17.1


### PR DESCRIPTION
**Address security vulnerabilities in gems**
* * *

# What does this Pull Request do?
Updates gems to address security vulnerabilities in the following gems:

- rack: CVE-2018-16471, CVE-2018-16470
- loofah: CVE-2018-16468
- rubyzip: CVE-2018-1000544
- sprockets: CVE-2018-3760

# What's the changes?
Updated the aforementioned vulnerable gems via `bundle update rack loofah rubyzip sprockets`.

# How should this be tested?

Deploy this branch of `VTUL/compel` and check that the application still works.


# Interested parties
@VTUL/dld-dev 
